### PR TITLE
Jvm inplace predict

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1000,33 +1000,6 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              const float **out_result);
 
 /*!
- * \brief make prediction based on dmat (deprecated, use `XGBoosterPredictFromDMatrix` instead)
- * \param handle handle
- * \param dmat data matrix
- * \param missing value in the input data which needs to be present as a missing value
- * \param option_mask bit-mask of options taken in prediction, possible values
- *          0:normal prediction
- *          1:output margin instead of transformed value
- *          2:output leaf index of trees instead of leaf value, note leaf index is unique per tree
- *          4:output feature contributions to individual predictions
- * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
- *    when the parameter is set to 0, we will use all the trees\param out_len used to store length of returning result
- * \param out_len used to store length of returning result
- * \param out_result used to set a pointer to array
- * \return 0 when success, -1 when failure happens
-*/
-XGB_DLL int XGBoosterInplacePredict(BoosterHandle handle,
-                                    const float *data,
-                                    size_t num_rows,
-                                    size_t num_features,
-                                    DMatrixHandle d_matrix_handle,
-                                    float missing,
-                                    int option_mask,
-                                    int ntree_limit,
-                                    const bst_ulong **len,
-                                    const float **out_result);
-
-/*!
  * \brief Make prediction from DMatrix, replacing \ref XGBoosterPredict.
  *
  * \param handle Booster handle

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -39,15 +39,12 @@ public class Booster implements Serializable, KryoSerializable {
   // handle to the booster.
   private long handle = 0;
   private int version = 0;
-
+  /**
+   * Type of prediction, used for inplace_predict.
+   */
   public enum PredictionType {
     kValue(0),
-    kMargin(1),
-    kContribution(2),
-    kApproxContribution(3),
-    kInteraction(4),
-    kApproxInteraction(5),
-    kLeaf(6);
+    kMargin(1);
 
     private Integer ptype;
     private PredictionType(final Integer ptype) {
@@ -334,10 +331,20 @@ public class Booster implements Serializable, KryoSerializable {
     return predicts;
   }
 
+  /**
+   * Perform thread-safe prediction.
+   *
+   * @param data      Flattened input matrix of features for prediction
+   * @param nrow      The number of preditions to make (count of input matrix rows)
+   * @param ncol      The number of features in the model (count of input matrix columns)
+   * @param missing   Value indicating missing element in the <code>data</code> input matrix
+   *
+   * @return predict  Result matrix
+   */
   public float[][] inplace_predict(float[] data,
-      int nrow,
-      int ncol,
-      float missing) throws XGBoostError {
+                                   int nrow,
+                                   int ncol,
+                                   float missing) throws XGBoostError {
     int[] iteration_range = new int[2];
     iteration_range[0] = 0;
     iteration_range[1] = 0;
@@ -346,24 +353,24 @@ public class Booster implements Serializable, KryoSerializable {
   }
 
   /**
-   * Perform thread-safe prediction. Calls
-   * <code>inplace_predict(data, num_rows, num_features, missing, false, 0, false, false)</code>.
+   * Perform thread-safe prediction.
    *
    * @param data      Flattened input matrix of features for prediction
    * @param nrow      The number of preditions to make (count of input matrix rows)
    * @param ncol      The number of features in the model (count of input matrix columns)
    * @param missing   Value indicating missing element in the <code>data</code> input matrix
+   * @param iteration_range Specifies which layer of trees are used in prediction.  For
+   *                        example, if a random forest is trained with 100 rounds.
+   *                        Specifying `iteration_range=[10, 20)`, then only the forests
+   *                        built during [10, 20) (half open set) rounds are used in this
+   *                        prediction.
    *
-   * @return predict       Result matrix
-   *
-   * @see #inplace_predict(float[] data, int num_rows, int num_features, float missing,
-   *                       boolean outputMargin, int treeLimit, boolean predLeaf,
-   *                       boolean predContribs)
+   * @return predict  Result matrix
    */
   public float[][] inplace_predict(float[] data,
-      int nrow,
-      int ncol,
-      float missing, int[] iteration_range) throws XGBoostError {
+                                   int nrow,
+                                   int ncol,
+                                   float missing, int[] iteration_range) throws XGBoostError {
     return this.inplace_predict(data, nrow, ncol,
         missing, iteration_range, PredictionType.kValue, null);
   }
@@ -372,20 +379,25 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Perform thread-safe prediction.
    *
-   * @param data           Flattened input matrix of features for prediction
-   * @param nrow       The number of preditions to make (count of input matrix rows)
-   * @param ncol   The number of features in the model (count of input matrix columns)
-   * @param missing        Value indicating missing element in the <code>data</code> input matrix
-   *
+   * @param data            Flattened input matrix of features for prediction
+   * @param nrow            The number of preditions to make (count of input matrix rows)
+   * @param ncol            The number of features in the model (count of input matrix columns)
+   * @param missing         Value indicating missing element in the <code>data</code> input matrix
+   * @param iteration_range Specifies which layer of trees are used in prediction.  For
+   *                        example, if a random forest is trained with 100 rounds.
+   *                        Specifying `iteration_range=[10, 20)`, then only the forests
+   *                        built during [10, 20) (half open set) rounds are used in this
+   *                        prediction.
+   * @param predict_type    What kind of prediction to run.
    * @return predict       Result matrix
    */
   public float[][] inplace_predict(float[] data,
-      int nrow,
-      int ncol,
-      float missing,
-      int[] iteration_range,
-      PredictionType predict_type,
-      float[] base_margin) throws XGBoostError {
+                                   int nrow,
+                                   int ncol,
+                                   float missing,
+                                   int[] iteration_range,
+                                   PredictionType predict_type,
+                                   float[] base_margin) throws XGBoostError {
     if (iteration_range.length != 2) {
       throw new XGBoostError(new String("Iteration range is expected to be [begin, end)."));
     }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -40,6 +40,16 @@ public class Booster implements Serializable, KryoSerializable {
   private long handle = 0;
   private int version = 0;
 
+    public enum PredictionType {
+	kValue (0),
+	kMargin (1),
+	kContribution (2),
+	kApproxContribution(3),
+	kInteraction (4),
+	kApproxInteraction (5),
+	kLeaf (6)
+    }
+
   /**
    * Create a new Booster with empty stage.
    *
@@ -360,60 +370,6 @@ public class Booster implements Serializable, KryoSerializable {
                 missing, false, 0, false, false);
   }
 
-  /**
-   * Perform thread-safe prediction. Calls
-   * <code>inplace_predict(data, num_rows, num_features, missing,
-   *                       outputMargin, 0, false, false)</code>.
-   *
-   * @param data           Flattened input matrix of features for prediction
-   * @param num_rows       The number of preditions to make (count of input matrix rows)
-   * @param num_features   The number of features in the model (count of input matrix columns)
-   * @param missing        Value indicating missing element in the <code>data</code> input matrix
-   * @param outputMargin   Whether to only predict margin value instead of transformed prediction
-   *
-   * @return predict       Result matrix
-   *
-   * @see #inplace_predict(float[] data, int num_rows, int num_features, float missing,
-   *                       boolean outputMargin, int treeLimit, boolean predLeaf,
-   *                       boolean predContribs)
-   */
-
-  public float[][] inplace_predict(float[] data,
-                                   int num_rows,
-                                   int num_features,
-                                   float missing,
-                                   boolean outputMargin) throws XGBoostError {
-    return this.inplace_predict(data, num_rows, num_features, missing,
-                       outputMargin, 0, false, false);
-  }
-
-  /**
-   * Perform thread-safe prediction. Calls
-   * <code>inplace_predict(data, num_rows, num_features, missing,
-   *                       outputMargin, treeLimit, false, false)</code>.
-   *
-   * @param data           Flattened input matrix of features for prediction
-   * @param num_rows       The number of preditions to make (count of input matrix rows)
-   * @param num_features   The number of features in the model (count of input matrix columns)
-   * @param missing        Value indicating missing element in the <code>data</code> input matrix
-   * @param outputMargin   Whether to only predict margin value instead of transformed prediction
-   * @param treeLimit      limit number of trees, 0 means all trees.
-   *
-   * @return predict       Result matrix
-   *
-   * @see #inplace_predict(float[] data, int num_rows, int num_features, float missing,
-   *                       boolean outputMargin, int treeLimit, boolean predLeaf,
-   *                       boolean predContribs)
-   */
-  public float[][] inplace_predict(float[] data,
-                                   int num_rows,
-                                   int num_features,
-                                   float missing,
-                                   boolean outputMargin,
-                                   int treeLimit) throws XGBoostError {
-    return this.inplace_predict(data, num_rows, num_features, missing,
-                                outputMargin, treeLimit, false, false);
-  }
 
   /**
    * Perform thread-safe prediction.
@@ -433,29 +389,13 @@ public class Booster implements Serializable, KryoSerializable {
   public float[][] inplace_predict(float[] data,
                                    int num_rows,
                                    int num_features,
-                                   float missing,
-                                   boolean outputMargin,
-                                   int treeLimit,
-                                   boolean predLeaf,
-                                   boolean predContribs) throws XGBoostError {
-    int optionMask = 0;
-    if (outputMargin) {
-      optionMask = 1;
-    }
-    if (predLeaf) {
-      optionMask = 2;
-    }
-    if (predContribs) {
-      optionMask = 4;
-    }
+                                   float missing
+				   PredictionType predict_type) throws XGBoostError {
     DMatrix d_mat = new DMatrix(data, num_rows, num_features, missing);
     float[][] rawPredicts = new float[1][];
     XGBoostJNI.checkCall(XGBoostJNI.XGBoosterInplacePredict(handle, data, num_rows, num_features,
         d_mat.getHandle(), missing,
         optionMask, treeLimit, rawPredicts));  // pass missing and treelimit here?
-
-    // System.out.println("Booster.inplace_predict rawPredicts[0].length = " +
-    //    rawPredicts[0].length);
 
     int row = num_rows;
     int col = rawPredicts[0].length / row;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -119,8 +119,9 @@ class XGBoostJNI {
   public final static native int XGBoosterPredict(long handle, long dmat, int option_mask,
                                                   int ntree_limit, float[][] predicts);
 
-  public final static native int XGBoosterInplacePredict(long handle, long d_matrix_handle,
-                                                        float missing, int predict_type);
+  public final static native int XGBoosterPredictFromDense(long handle, float[] data,
+      long nrow, long ncol, float missing, int iteration_begin, int iteration_end, int predict_type, float[] margin,
+      float[][] predicts);
 
   public final static native int XGBoosterLoadModel(long handle, String fname);
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -119,9 +119,8 @@ class XGBoostJNI {
   public final static native int XGBoosterPredict(long handle, long dmat, int option_mask,
                                                   int ntree_limit, float[][] predicts);
 
-  public final static native int XGBoosterInplacePredict(long handle, float[] data, int num_rows, int num_features, long d_matrix_handle,
-                                                         float missing, int option_mask, int ntree_limit,
-                                                         float[][] predicts);
+  public final static native int XGBoosterInplacePredict(long handle, long d_matrix_handle,
+                                                        float missing, int predict_type);
 
   public final static native int XGBoosterLoadModel(long handle, String fname);
 
@@ -157,10 +156,6 @@ class XGBoostJNI {
 
   public final static native int XGDMatrixSetInfoFromInterface(
     long handle, String field, String json);
-
-  @Deprecated
-  public final static native int XGDeviceQuantileDMatrixCreateFromCallback(
-    java.util.Iterator<ColumnBatch> iter, float missing, int nthread, int maxBin, long[] out);
 
   public final static native int XGQuantileDMatrixCreateFromCallback(
     java.util.Iterator<ColumnBatch> iter, java.util.Iterator<ColumnBatch> ref, String config, long[] out);

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -690,6 +690,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   config["type"] = xgboost::Integer{predict_type};
   config["iteration_begin"] = xgboost::Integer{iteration_begin};
   config["iteration_end"] = xgboost::Integer{iteration_end};
+  config["missing"] = xgboost::Number{missing};
   std::string s_config;
   xgboost::Json::Dump(config, &s_config);
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -683,9 +683,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
       xgboost::Context::kCpuId,
       xgboost::common::Span{data, static_cast<std::size_t>(num_rows * num_features)}, num_rows,
       num_features);
-  auto array = linalg::ArrayInterface(t_data);
-  std::string s_array;
-  xgboost::Json::Dump(array, &s_array);
+  auto s_array = linalg::ArrayInterfaceStr(t_data);
 
   /**
    * Create configuration object.

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -691,11 +691,11 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
    * Create configuration object.
    */
   xgboost::Json config{xgboost::Object{}};
-  config["cache_id"] = xgboost::Integer{0};
-  config["type"] = xgboost::Integer{predict_type};
-  config["iteration_begin"] = xgboost::Integer{iteration_begin};
-  config["iteration_end"] = xgboost::Integer{iteration_end};
-  config["missing"] = xgboost::Number{missing};
+  config["cache_id"] = xgboost::Integer{};
+  config["type"] = xgboost::Integer{static_cast<std::int32_t>(predict_type)};
+  config["iteration_begin"] = xgboost::Integer{static_cast<xgboost::bst_layer_t>(iteration_begin)};
+  config["iteration_end"] = xgboost::Integer{static_cast<xgboost::bst_layer_t>(iteration_end)};
+  config["missing"] = xgboost::Number{static_cast<float>(missing)};
   config["strict_shape"] = xgboost::Boolean{true};
   std::string s_config;
   xgboost::Json::Dump(config, &s_config);
@@ -718,8 +718,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   float const *result;
   auto ret = XGBoosterPredictFromDense(handle, s_array.c_str(), s_config.c_str(), proxy, &out_shape,
                                        &out_dim, &result);
-  jenv->ReleaseFloatArrayElements(jdata, data, 0);
 
+  jenv->ReleaseFloatArrayElements(jdata, data, 0);
   if (proxy) {
     XGDMatrixFree(proxy);
     jenv->ReleaseFloatArrayElements(jmargin, margin, 0);
@@ -739,7 +739,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   jenv->SetFloatArrayRegion(jarray, 0, n, result);
   jenv->SetObjectArrayElement(jout, 0, jarray);
 
-  return ret;
   API_END();
 }
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -19,7 +19,6 @@
 #include <xgboost/c_api.h>
 #include <xgboost/json.h>
 #include <xgboost/logging.h>
-#include <fstream>
 
 #include <cstddef>
 #include <cstdint>

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -209,11 +209,12 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
- * Method:    XGBoosterInplacePredict
- * Signature: (J[FIII[[F)I
+ * Method:    XGBoosterPredictFromDense
+ * Signature: (J[FJJFIII[F[[F)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterInplacePredict
-  (JNIEnv *, jclass, jlong, jfloatArray, jint, jint, jlong, jfloat, jint, jint, jobjectArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFromDense
+  (JNIEnv *, jclass, jlong, jfloatArray, jlong, jlong, jfloat, jint, jint, jint, jfloatArray, jobjectArray);
+
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterLoadModel
@@ -365,14 +366,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorAllred
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetInfoFromInterface
   (JNIEnv *, jclass, jlong, jstring, jstring);
-
-/*
- * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
- * Method:    XGDeviceQuantileDMatrixCreateFromCallback
- * Signature: (Ljava/util/Iterator;FII[J)I
- */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDeviceQuantileDMatrixCreateFromCallback
-  (JNIEnv *, jclass, jobject, jfloat, jint, jint, jlongArray);
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -133,7 +133,10 @@ class InplacePredictionTask implements Callable<Boolean> {
       int r = this.rng.nextInt(this.test_rows);
 
       // In-place predict a single random row
-      float[][] predictions = booster.inplace_predict(this.testX[r], 1, this.features);
+      int[] iteration_range = new int[2];
+      iteration_range[0] = 0;
+      iteration_range[1] = 0;
+      float[][] predictions = booster.inplace_predict(this.testX[r], 1, this.features, Float.NaN, iteration_range);
 
       // Confirm results as expected
       if (predictions[0][0] != this.true_predicts[r][0]) {
@@ -292,7 +295,7 @@ public class BoosterImplTest {
     float[][] predicts = booster.predict(testMat);
 
     // inplace prediction
-    float[][] inplace_predicts = booster.inplace_predict(testX, test_rows, features);
+    float[][] inplace_predicts = booster.inplace_predict(testX, test_rows, features, Float.NaN);
 
     // Confirm that the two prediction results are identical
     assertArrayEquals(predicts, inplace_predicts);

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -87,7 +87,7 @@ class InplacePredictThread extends Thread {
         int r = this.rng.nextInt(this.test_rows);
 
         // In-place predict a single random row
-        float[][] predictions = booster.inplace_predict(this.testX[r], 1, this.features);
+        float[][] predictions = booster.inplace_predict(this.testX[r], 1, this.features, Float.NaN);
 
         // Confirm results as expected
         if (predictions[0][0] != this.true_predicts[r][0]) {

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1018,26 +1018,6 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle,
   API_END();
 }
 
-void InplacePredictImplCore(std::shared_ptr<DMatrix> p_m,
-                            Learner *learner,
-                            xgboost::PredictionType type,
-                            float missing,
-                            size_t n_rows, size_t n_cols,
-                            size_t iteration_begin, size_t iteration_end,
-                            bool strict_shape,
-                            xgboost::bst_ulong const **out_shape,
-                            xgboost::bst_ulong *out_dim, const float **out_result) {
-  HostDeviceVector<float>* p_predt { nullptr };
-  learner->InplacePredict(p_m, type, missing, &p_predt, iteration_begin, iteration_end);
-  CHECK(p_predt);
-  auto &shape = learner->GetThreadLocal().prediction_shape;
-  auto chunksize = n_rows == 0 ? 0 : p_predt->Size() / n_rows;
-  CalcPredictShape(strict_shape, type, n_rows, n_cols, chunksize, learner->Groups(),
-                   learner->BoostedRounds(), &shape, out_dim);
-  *out_result = dmlc::BeginPtr(p_predt->HostVector());
-  *out_shape = dmlc::BeginPtr(shape);
-}
-
 void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config, Learner *learner,
                         xgboost::bst_ulong const **out_shape, xgboost::bst_ulong *out_dim,
                         const float **out_result) {
@@ -1045,23 +1025,29 @@ void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config,
   auto config = Json::Load(StringView{c_json_config});
   CHECK_EQ(get<Integer const>(config["cache_id"]), 0) << "Cache ID is not supported yet";
 
+  HostDeviceVector<float> *p_predt{nullptr};
   auto type = PredictionType(RequiredArg<Integer>(config, "type", __func__));
   float missing = GetMissing(config);
+  learner->InplacePredict(p_m, type, missing, &p_predt,
+                          RequiredArg<Integer>(config, "iteration_begin", __func__),
+                          RequiredArg<Integer>(config, "iteration_end", __func__));
+  CHECK(p_predt);
+  auto &shape = learner->GetThreadLocal().prediction_shape;
   auto const &info = p_m->Info();
   auto n_samples = info.num_row_;
   auto n_features = info.num_col_;
-  int iteration_begin = get<Integer const>(config["iteration_begin"]);
-  int iteration_end   = get<Integer const>(config["iteration_end"]);
+  auto chunksize = n_samples == 0 ? 0 : p_predt->Size() / n_samples;
   bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
 
   xgboost_CHECK_C_ARG_PTR(out_dim);
+  CalcPredictShape(strict_shape, type, n_samples, n_features, chunksize, learner->Groups(),
+                   learner->BoostedRounds(), &shape, out_dim);
 
   xgboost_CHECK_C_ARG_PTR(out_result);
   xgboost_CHECK_C_ARG_PTR(out_shape);
 
-  InplacePredictImplCore(p_m, learner, type, missing, n_samples, n_features,
-                         iteration_begin, iteration_end, strict_shape, out_shape,
-                         out_dim, out_result);
+  *out_result = dmlc::BeginPtr(p_predt->HostVector());
+  *out_shape = dmlc::BeginPtr(shape);
 }
 
 XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_interface,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1064,29 +1064,6 @@ void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config,
                          out_dim, out_result);
 }
 
-XGB_DLL int XGBoosterInplacePredict(BoosterHandle handle,
-                                    const float *data,
-                                    size_t num_rows,
-                                    size_t num_features,
-                                    DMatrixHandle dMatrixHandle,
-                                    float missing,
-                                    int option_mask,
-                                    int ntree_limit,
-                                    const xgboost::bst_ulong **len,
-                                    const bst_float **out_result) {
-  API_BEGIN();
-  CHECK_HANDLE();
-  xgboost::bst_ulong out_dim;
-
-  auto *learner = static_cast<xgboost::Learner *>(handle);
-  auto iteration_end = GetIterationFromTreeLimit(ntree_limit, learner);
-  auto proxy = std::make_shared<data::DMatrixProxy>();
-  proxy->SetDenseData(data, num_rows, num_features);
-  InplacePredictImplCore(proxy, learner, (xgboost::PredictionType)0, missing, num_rows,
-                         num_features, 0, iteration_end, true, len, &out_dim, out_result);
-  API_END();
-}
-
 XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_interface,
                                       char const *c_json_config, DMatrixHandle m,
                                       xgboost::bst_ulong const **out_shape,

--- a/src/data/proxy_dmatrix.cc
+++ b/src/data/proxy_dmatrix.cc
@@ -15,16 +15,6 @@ void DMatrixProxy::SetArrayData(char const *c_interface) {
   this->ctx_.gpu_id = Context::kCpuId;
 }
 
-void DMatrixProxy::SetDenseData(const float *data, size_t num_rows,
-                                size_t num_features) {
-  std::shared_ptr<xgboost::data::DenseAdapter> adapter{new xgboost::data::DenseAdapter(
-      data, num_rows, num_features)};
-  this->batch_ = adapter;
-  this->Info().num_col_ = adapter->NumColumns();
-  this->Info().num_row_ = adapter->NumRows();
-  this->ctx_.gpu_id = Context::kCpuId;
-}
-
 void DMatrixProxy::SetCSRData(char const *c_indptr, char const *c_indices,
                               char const *c_values, bst_feature_t n_features, bool on_host) {
   CHECK(on_host) << "Not implemented on device.";

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -63,11 +63,8 @@ class DMatrixProxy : public DMatrix {
   }
 
   void SetArrayData(char const* c_interface);
-  void SetDenseData(const float *data, size_t num_rows,
-                    size_t num_features);
-  void SetCSRData(char const *c_indptr, char const *c_indices,
-                  char const *c_values, bst_feature_t n_features,
-                  bool on_host);
+  void SetCSRData(char const* c_indptr, char const* c_indices, char const* c_values,
+                  bst_feature_t n_features, bool on_host);
 
   MetaInfo& Info() override { return info_; }
   MetaInfo const& Info() const override { return info_; }


### PR DESCRIPTION
@yoquinjo Could you please take a look? This is a draft of the changes needed to use the internal inplace predict function based on your existing patch.

- Use the `PredictFromDense` function to implement inplace prediction, which doesn't make a data copy.